### PR TITLE
fix: updated Ci pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,9 @@ jobs:
             - name: setup python
               uses: actions/setup-python@v5            
               with: 
-                python-version: '3.11'
+                python-version: |
+                                '3.11'
+                                '3.12'
                 
             
             - name: install dependencies


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured ci pipeline.  

## Related Task  
[HNG12 Stage 2 Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739195475622999?thread_ts=1739195475.622999&cid=C088PK3KE2K)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/895`) to confirm 404 response.